### PR TITLE
changing pest 'node' rule to accept empty node

### DIFF
--- a/sgf.pest
+++ b/sgf.pest
@@ -2,7 +2,7 @@ WHITESPACE = _{ " " | NEWLINE}
 
 game_tree = { "(" ~ sequence? ~ game_tree* ~ ")"}
 sequence = { node{1,} }
-node = { ";" ~ property+ }
+node = { ";" ~ property* }
 property = { property_identifier ~ property_value+ }
 property_identifier = { ('A'..'Z' | 'a'..'z')+ }
 property_value = ${ "[" ~ inner ~ "]" }

--- a/tests/sgf/empty_node.sgf
+++ b/tests/sgf/empty_node.sgf
@@ -1,0 +1,1 @@
+(;AP[AInalyzer:0.1.0]CA[UTF-8]FF[4]GM[1]KM[6.5]PB[Black]PW[White]RU[Japanese]ST[0]SZ[19](;B[cf](;;W[bj](;B[jo](;W[oi](;B[kh](;W[kj](;B[ll]))))))))

--- a/tests/sgf_file.rs
+++ b/tests/sgf_file.rs
@@ -41,4 +41,9 @@ mod sgf_files_test {
             _ => false,
         })
     }
+
+    #[test]
+    fn parse_sgf_with_empty_node() {
+        let _g = sgf_parser::parse(include_str!("sgf/empty_node.sgf")).unwrap();
+    }
 }


### PR DESCRIPTION
I am proposing this pull request to accept empty nodes when parsing.

When writing an app using sgf_parser, I tried to load a pretty big sgf file which is a collection of josekis named "Kogo's Joseki Dictionary". You can find it here: http://waterfire.us/joseki.htm

The problem is, I can't parse this file because far into the sgf, there is an empty node (i.e: `;;B[...]...` the first `;` is an empty node). Right now sgf_parser panic on it but if we change the rule

`node = { ";" ~ property+ }`
to
`node = { ";" ~ property* }`

the file is parsed and it creates a node with an empty tokens vec, which doesn't seem problematic to me.
I'd like this to be merged because I don't really want to use my own forked version of sgf_parser and think it would be better that this change makes it to master.